### PR TITLE
Make fzf-history's exec key work again

### DIFF
--- a/zsh-fzf-widgets.zsh
+++ b/zsh-fzf-widgets.zsh
@@ -65,7 +65,7 @@ fzf-history() {
       -n2..,..
       --tiebreak=index
       --bind=${ZSH_FZF_PASTE_KEY}:accept
-      --bind=\"${ZSH_FZF_EXEC_KEY}:execute@echo -\$(echo {} | sed -e 's/^ //')@+abort\"
+      --bind=\"${ZSH_FZF_EXEC_KEY}:become@echo -\$(echo {} | sed -e 's/^ //')@\"
       " ${=FZF_CMD}))
   if [ -n "$res" ]; then
     local num=$res[1]


### PR DESCRIPTION
Recently the exec key (`enter`) stopped working for `fzf-history`. It stopped doing anything at all forcing me to always pasting (`tab` key) and then running the command. I suspect that it could be related to the recent release of 0.53 of fzf, but I'm not sure.

This change makes `fzf-history`'s exec key work again.